### PR TITLE
ブロックの落下処理、ブロックの固定処理、ブロックの回転及び移動処理の追加

### DIFF
--- a/game.c
+++ b/game.c
@@ -1,22 +1,56 @@
 #include <stdio.h>
-#include <stdlib.h> // system使用
-#include <string.h> // memset使用
+#include <stdlib.h> // system使用 rand,srand使用
+#include <string.h> // memset,memcpy使用
+#include <time.h>   // time使用
 #include "tetris_game.h"
 
 void init_game()
 {
+    srand(time(0));
     system(" cls ");
+
+    memset(board, 0, sizeof(board)); // boardの0初期化
 
     for (int i = 0; i < ROW - 1; i++)
     {
         memset(field[i], ' ', COL - 1); // 第1:初期化したいメモリ領域の先頭アドレス  第2:セットしたい値(1バイト単位)　第3:セットするバイト数
-        field[i][COL - 1] = '\0';
-        if (i >= 2)
-        {
-            field[i][0] = '|';
-            field[i][COL - 2] = '|';
-        }
+        field[i][COL - 1] = '\0';       // 文字列終端
+        field[i][0] = '|';              // 左枠
+        field[i][COL - 2] = '|';        // 右枠
     }
     memset(field[ROW - 1], '-', COL - 1);
     field[ROW - 1][COL - 1] = '\0';
+}
+
+void init_block(Block *dest, Block *src) // dest = destination：コピー先　　src = source：コピー元
+{
+    memcpy(dest, src, sizeof(Block)); // memcpy：メモリ内容をコピーする。配列や構造体をまとめてコピーしたい時に使う。
+    dest->px = 5;
+    dest->py = 0;
+    dest->rot = 0;
+}
+
+int is_collision(Block *block)
+{ // 構造体はデータが大きいのでポインタで渡す
+    for (int i = 0; i < 4; i++)
+    {
+        int x = block->px + block->x[i];
+        int y = block->py + block->y[i] + 1; // 次の位置
+
+        if (y >= ROW - 1 || board[y][x] != 0)
+        {
+            return 1; // 衝突あり
+        }
+    }
+    return 0; // 衝突なし
+}
+
+void fix_block(Block *block)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        int x = block->px + block->x[i];
+        int y = block->py + block->y[i];
+        board[y][x] = 1; // 固定
+    }
 }

--- a/main.c
+++ b/main.c
@@ -2,38 +2,68 @@
 #include <stdlib.h> // system使用
 #include <string.h> // memset使用
 #include <unistd.h> // sleep使用
+#include <time.h>   // time使用
 #include "tetris_game.h"
 
+int board[10][10];
 char field[ROW][COL];
 
 Block blocks[BLOCK_TYPE_COUNT] = {
     // ブロックセット構造体を作って持たせる方法もある
-    {{0, -1, 1, 2}, {0, 0, 0, 0}, 5, 2, 0, 0, '+'}, // I
-    {{0, 1, 0, 1}, {0, 0, 1, 1}, 5, 2, 1, 0, '+'},  // O
-    {{0, -1, 1, 0}, {0, 0, 0, 1}, 5, 2, 2, 0, '+'}, // T
-    {{0, 1, -1, 0}, {0, 0, 1, 1}, 5, 2, 3, 0, '+'}, // S
-    {{0, -1, 1, 0}, {0, 0, 1, 1}, 5, 2, 4, 0, '+'}, // Z
-    {{0, -1, 1, 1}, {0, 0, 0, 1}, 5, 2, 5, 0, '+'}, // J
-    {{0, 1, 2, 0}, {0, 0, 0, 1}, 5, 2, 6, 0, '+'},  // L
+    {{0, -1, 1, 2}, {0, 0, 0, 0}, 5, 0, 0, 0, '+'}, // I
+    {{0, 1, 0, 1}, {0, 0, 1, 1}, 5, 0, 1, 0, '+'},  // O
+    {{0, -1, 1, 0}, {0, 0, 0, 1}, 5, 0, 2, 0, '+'}, // T
+    {{0, 1, -1, 0}, {0, 0, 1, 1}, 5, 0, 3, 0, '+'}, // S
+    {{0, -1, 1, 0}, {0, 0, 1, 1}, 5, 0, 4, 0, '+'}, // Z
+    {{0, -1, 1, 1}, {0, 0, 0, 1}, 5, 0, 5, 0, '+'}, // J
+    {{0, 1, 2, 0}, {0, 0, 0, 1}, 5, 0, 6, 0, '+'},  // L
 };
+// 必ず、基点から配列要素を組み立てる必要有。また、0行目から組み立て必要。
+Block block; // 作業用の空のブロック(ゲームに登場したブロック格納用)  これは他のファイルでは使わない。
+Block *current_block = &block;
+int block_shape;
+int block_fixed = 0;
+
+pthread_mutex_t block_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int main(void)
 {
+    pthread_t input_key_thread;
+    //  pthread_t screen_thread;
     init_game();
 
-    while (1)
+    pthread_create(&input_key_thread, NULL, detect_input, NULL);
+
+    for (;;)
     {
-        for (int i = 2; i < ROW - 2; i++)
-        { // ROW - 3枠線の2個上
-            blocks[BLOCK_T].py = i;
-            for (int j = 0; j < 4; j++)
+        block_shape = rand() % BLOCK_TYPE_COUNT;
+        init_block(current_block, &blocks[block_shape]);
+        block_fixed = 0;
+        while (1)
+        {
+            pthread_mutex_lock(&block_mutex); // ロック
+            for (int i = 0; i < 4; i++)
             {
-                int x = blocks[BLOCK_T].px + blocks[BLOCK_T].x[j];
-                int y = blocks[BLOCK_T].py + blocks[BLOCK_T].y[j];
-                field[y][x] = blocks[BLOCK_T].symbol;
+                int x = current_block->px + current_block->x[i];
+                int y = current_block->py + current_block->y[i];
+                field[y][x] = current_block->symbol;
             }
+            pthread_mutex_unlock(&block_mutex); // ロック解除
+
             print_screen();
-            clear_block();
+
+            pthread_mutex_lock(&block_mutex); // ロック
+            if (is_collision(current_block))
+            {
+                fix_block(current_block);
+                pthread_mutex_unlock(&block_mutex); // ロック解除
+                block_fixed = 1;
+                break;
+            }
+            clear_block(current_block);
+            current_block->py++; // 落下
+
+            pthread_mutex_unlock(&block_mutex); // ロック解除
         }
     }
     return 0;

--- a/player.c
+++ b/player.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <conio.h>  // kbhit,getch使用
+#include <unistd.h> // sleep使用
+#include "tetris_game.h"
+
+void *detect_input(void *ptr)
+{
+    for (;;)
+    {
+        if (kbhit())
+        {
+            int key = getch();
+
+            pthread_mutex_lock(&block_mutex); // ロック
+            if (key == ' ')
+            {
+                if (!block_fixed)
+                {
+                    clear_block(current_block);  // 先に消さないと、回転前の+が残る
+                    rotate_block(current_block); // current_block自体はポインタ変数。*でポインタが指し示す値
+                }
+            }
+            else
+            {
+                if (key == 72 || key == 80 || key == 75 || key == 77)
+                {
+                    if (!block_fixed)
+                    {
+                        clear_block(current_block); // 先に消さないと、移動前の+が残る
+                        switch (key)
+                        {
+                        case 80:                                  // 下
+                            while (can_move(current_block, 0, 1)) // 限界まで落とす
+                                current_block->py++;
+                            break;
+                        case 75: // 左
+                            if (can_move(current_block, -1, 0))
+                                current_block->px--;
+                            break;
+                        case 77: // 右
+                            if (can_move(current_block, 1, 0))
+                                current_block->px++;
+                            break;
+                        default:
+                        }
+                    }
+                }
+            }
+            pthread_mutex_unlock(&block_mutex); // ロック解除
+        }
+        usleep(10000);
+    }
+    return NULL;
+}
+
+void rotate_block(Block *block)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        int old_x = block->x[i];
+        int old_y = block->y[i];
+        block->x[i] = -old_y;
+        block->y[i] = old_x;
+    }
+    // 時計回り(90度回転)  x' = -y    y' = x
+    // 反時計回り(90度回転) x' = y    x' = -x
+
+    block->rot = (block->rot + 1) % 4;
+}
+
+int can_move(Block *block, int dx, int dy)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        int x = block->px + block->x[i] + dx;
+        int y = block->py + block->y[i] + dy;
+
+        if (x < 1 || x >= 11 || y < 0 || y >= 10 || board[y][x] != 0) // board[y][x] != 0でブロックがあると動けない処理も含まれている
+        {
+            return 0; // 移動できない
+        }
+    }
+    return 1; // 移動できる
+}

--- a/screen.c
+++ b/screen.c
@@ -4,19 +4,21 @@
 
 void print_screen()
 {
+    printf("\033[1;1H"); // 画面の上塗り
+
     for (int i = 0; i < ROW; i++)
     {
         printf("%s\n", field[i]);
     }
-    usleep(300000);
+    usleep(800000);
 }
 
-void clear_block()
+void clear_block(Block *block)
 {
     for (int i = 0; i < 4; i++)
     {
-        int x = blocks[BLOCK_T].px + blocks[BLOCK_T].x[i];
-        int y = blocks[BLOCK_T].py + blocks[BLOCK_T].y[i];
+        int x = block->px + block->x[i];
+        int y = block->py + block->y[i];
         field[y][x] = ' ';
     }
 }

--- a/tetris_game.h
+++ b/tetris_game.h
@@ -1,24 +1,10 @@
 #ifndef TETRIS_GAME_H
 #define TETRIS_GAME_H
 
-#define ROW 13 // 最後行枠用。上位2行ゲームオーバー用
-#define COL 22 // 1列目及び最終列 - 1枠用。最終列はnull文字用
+#include <pthread.h> // mutex使用(各ファイルスレッド使用)
 
-/*  関数のプロトタイプ宣言  */
-void init_game();
-void print_screen();
-void clear_block();
-
-// extern int board[24][10];    // 内部用
-extern char field[ROW][COL]; // 表示用
-
-/* 座標
-       -y
-　　　  ↑
--x　←　中心　→　+x
-　　　  ↓
-       +y
-*/
+#define ROW 11 // 最後行枠用。上位2行ゲームオーバー用　　　　　 実際10
+#define COL 13 // 1列目及び最終列 - 1枠用。最終列はnull文字用  実際10
 
 typedef struct
 {                // typedefはBlockという名の構造体の型が使えるようにする型定義。つまり、Blockは変数ではない。externは変数の「外部参照」を宣言するため、一緒に使えず、Blockの型を宣言して、これにexternを付けるべき。
@@ -26,8 +12,8 @@ typedef struct
     int y[4];    // 各ブロックの相対y座標
     int px;      // フィールド上の相対x座標
     int py;      // フィールド上の相対y座標
-    int type;    // ブロックの種類(I,O,T,S,Z,J,L)
-    int rot;     // 回転状態(0,1,2,3)
+    int type;    // ブロックの種類(I,O,T,S,Z,J,L) ※今のところ用途なし
+    int rot;     // 回転状態(0,1,2,3)   0 = 0度   1 = 90度   2 = 180度   3 = 270度
     char symbol; // 描画用の記号
 
 } Block;
@@ -44,6 +30,31 @@ typedef enum
     BLOCK_TYPE_COUNT
 } BlockType;
 
+/*  関数のプロトタイプ宣言  */
+void init_game();
+void init_block(Block *dest, Block *src);
+void print_screen();
+void clear_block(Block *block);
+int is_collision(Block *block);
+void fix_block(Block *block);
+void rotate_block(Block *block);
+int can_move(Block *block, int dx, int dy);
+/*  スレッド関数プロトタイプ宣言  */
+void *detect_input(void *ptr);
+
 extern Block blocks[BLOCK_TYPE_COUNT]; // 構造体の型の別名BLOCK型の配列変数blocksにenumで作成したマクロを代入
+extern int board[10][10];              // 内部用　純粋なプレイ領域管理。null文字や枠線の管理不要
+extern char field[ROW][COL];           // 表示用
+/* 座標
+       -y
+　　　  ↑
+-x　←　中心　→　+x
+　　　  ↓
+       +y
+*/
+extern int block_shape;
+extern Block *current_block;
+extern pthread_mutex_t block_mutex;
+extern int block_fixed;
 
 #endif


### PR DESCRIPTION
# 機能
- 落下処理
- 固定処理
- 回転及び移動処理
   - 入力検知のスレッドに画面を消す処理を入れたため、固定直前で、回転や移動をすると、内部的にはブロックがある状態だが、表示上は消えてしまうバグがある。(Issuesで管理)
   -  両サイドの壁を乗り越えないような仕様にしているが、回転時に壁を壊すバグあり。(Issuesで管理)