### PR TITLE
回転処理及び移動のバグ修正

### DIFF
--- a/game.c
+++ b/game.c
@@ -25,6 +25,7 @@ void init_game()
 void init_block(Block *dest, Block *src) // dest = destination：コピー先　　src = source：コピー元
 {
     memcpy(dest, src, sizeof(Block)); // memcpy：メモリ内容をコピーする。配列や構造体をまとめてコピーしたい時に使う。
+    // この3行は構造体配列で初期値定義しているので、必要ないが、後々出現位置を変える場合もあるため、残す
     dest->px = 5;
     dest->py = 0;
     dest->rot = 0;

--- a/main.c
+++ b/main.c
@@ -22,8 +22,8 @@ Block blocks[BLOCK_TYPE_COUNT] = {
 Block block; // 作業用の空のブロック(ゲームに登場したブロック格納用)  これは他のファイルでは使わない。
 Block *current_block = &block;
 volatile InputType input_flag = INPUT_NONE;
+volatile int block_fixed = 0;
 int block_shape;
-int block_fixed = 0;
 
 pthread_mutex_t block_mutex = PTHREAD_MUTEX_INITIALIZER;
 

--- a/main.c
+++ b/main.c
@@ -21,6 +21,7 @@ Block blocks[BLOCK_TYPE_COUNT] = {
 // 必ず、基点から配列要素を組み立てる必要有。また、0行目から組み立て必要。
 Block block; // 作業用の空のブロック(ゲームに登場したブロック格納用)  これは他のファイルでは使わない。
 Block *current_block = &block;
+volatile InputType input_flag = INPUT_NONE;
 int block_shape;
 int block_fixed = 0;
 
@@ -38,32 +39,37 @@ int main(void)
     {
         block_shape = rand() % BLOCK_TYPE_COUNT;
         init_block(current_block, &blocks[block_shape]);
+
+        pthread_mutex_lock(&block_mutex); // ロック
         block_fixed = 0;
+        pthread_mutex_unlock(&block_mutex); // ロック解除
+
         while (1)
         {
-            pthread_mutex_lock(&block_mutex); // ロック
-            for (int i = 0; i < 4; i++)
-            {
-                int x = current_block->px + current_block->x[i];
-                int y = current_block->py + current_block->y[i];
-                field[y][x] = current_block->symbol;
-            }
-            pthread_mutex_unlock(&block_mutex); // ロック解除
+            // 前回位置削除
+            clear_block(current_block);
 
-            print_screen();
+            // 入力処理
+            handle_input();
 
-            pthread_mutex_lock(&block_mutex); // ロック
+            // 衝突判定
             if (is_collision(current_block))
             {
                 fix_block(current_block);
-                pthread_mutex_unlock(&block_mutex); // ロック解除
+                draw_block(current_block);
+                print_screen();
+                pthread_mutex_lock(&block_mutex); // ロック
                 block_fixed = 1;
+                pthread_mutex_unlock(&block_mutex); // ロック解除
                 break;
             }
-            clear_block(current_block);
-            current_block->py++; // 落下
 
-            pthread_mutex_unlock(&block_mutex); // ロック解除
+            // 自然落下
+            current_block->py++;
+
+            // 描画
+            draw_block(current_block);
+            print_screen();
         }
     }
     return 0;

--- a/player.c
+++ b/player.c
@@ -5,52 +5,70 @@
 
 void *detect_input(void *ptr)
 {
+
     for (;;)
     {
+        pthread_mutex_lock(&block_mutex);
+        int bf = !block_fixed;
+        pthread_mutex_unlock(&block_mutex);
         if (kbhit())
         {
             int key = getch();
-
-            pthread_mutex_lock(&block_mutex); // ロック
-            if (key == ' ')
+            if (bf)
             {
-                if (!block_fixed)
+                pthread_mutex_lock(&block_mutex);
+                switch (key)
                 {
-                    clear_block(current_block);  // 先に消さないと、回転前の+が残る
-                    rotate_block(current_block); // current_block自体はポインタ変数。*でポインタが指し示す値
+                case ' ':
+                    input_flag = INPUT_ROTATE;
+                    break;
+                case 75:
+                    input_flag = INPUT_LEFT;
+                    break;
+                case 77:
+                    input_flag = INPUT_RIGHT;
+                    break;
+                case 80:
+                    input_flag = INPUT_DOWN;
+                    break;
+                default:
+                    break;
                 }
+                pthread_mutex_unlock(&block_mutex);
             }
-            else
-            {
-                if (key == 72 || key == 80 || key == 75 || key == 77)
-                {
-                    if (!block_fixed)
-                    {
-                        clear_block(current_block); // 先に消さないと、移動前の+が残る
-                        switch (key)
-                        {
-                        case 80:                                  // 下
-                            while (can_move(current_block, 0, 1)) // 限界まで落とす
-                                current_block->py++;
-                            break;
-                        case 75: // 左
-                            if (can_move(current_block, -1, 0))
-                                current_block->px--;
-                            break;
-                        case 77: // 右
-                            if (can_move(current_block, 1, 0))
-                                current_block->px++;
-                            break;
-                        default:
-                        }
-                    }
-                }
-            }
-            pthread_mutex_unlock(&block_mutex); // ロック解除
         }
         usleep(10000);
     }
     return NULL;
+}
+
+void handle_input()
+{
+    pthread_mutex_lock(&block_mutex); // ロック
+    switch (input_flag)
+    {
+    case INPUT_LEFT:
+        if (can_move(current_block, -1, 0))
+            current_block->px--;
+        break;
+    case INPUT_RIGHT:
+        if (can_move(current_block, 1, 0))
+            current_block->px++;
+        break;
+    case INPUT_DOWN:
+        while (can_move(current_block, 0, 1))
+            current_block->py++;
+        break;
+    case INPUT_ROTATE:
+        rotate_block(current_block);
+        if (!can_move(current_block, 0, 0))      // 回転後に衝突するなら戻す。＋する分を0にして、今現状、領域外に行っているか確かめる
+            rotate_block_reverse(current_block); // 逆回転（未実装なら保存して戻す）
+        break;
+    default:
+        break;
+    }
+    input_flag = INPUT_NONE;            // 処理済み
+    pthread_mutex_unlock(&block_mutex); // ロック解除
 }
 
 void rotate_block(Block *block)
@@ -66,6 +84,18 @@ void rotate_block(Block *block)
     // 反時計回り(90度回転) x' = y    x' = -x
 
     block->rot = (block->rot + 1) % 4;
+}
+
+void rotate_block_reverse(Block *block)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        int old_x = block->x[i];
+        int old_y = block->y[i];
+        block->x[i] = old_y;
+        block->y[i] = -old_x;
+    }
+    block->rot = (block->rot + 3) % 4;
 }
 
 int can_move(Block *block, int dx, int dy)

--- a/screen.c
+++ b/screen.c
@@ -13,6 +13,16 @@ void print_screen()
     usleep(800000);
 }
 
+void draw_block(Block *block)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        int x = current_block->px + current_block->x[i];
+        int y = current_block->py + current_block->y[i];
+        field[y][x] = current_block->symbol;
+    }
+}
+
 void clear_block(Block *block)
 {
     for (int i = 0; i < 4; i++)

--- a/tetris_game.h
+++ b/tetris_game.h
@@ -30,21 +30,36 @@ typedef enum
     BLOCK_TYPE_COUNT
 } BlockType;
 
+typedef enum
+{
+    INPUT_NONE,
+    INPUT_LEFT,
+    INPUT_RIGHT,
+    INPUT_DOWN,
+    INPUT_ROTATE
+} InputType;
+
 /*  関数のプロトタイプ宣言  */
 void init_game();
 void init_block(Block *dest, Block *src);
 void print_screen();
+void draw_block(Block *block);
 void clear_block(Block *block);
 int is_collision(Block *block);
 void fix_block(Block *block);
 void rotate_block(Block *block);
+void rotate_block_reverse(Block *block);
 int can_move(Block *block, int dx, int dy);
+void handle_input();
 /*  スレッド関数プロトタイプ宣言  */
 void *detect_input(void *ptr);
 
 extern Block blocks[BLOCK_TYPE_COUNT]; // 構造体の型の別名BLOCK型の配列変数blocksにenumで作成したマクロを代入
 extern int board[10][10];              // 内部用　純粋なプレイ領域管理。null文字や枠線の管理不要
 extern char field[ROW][COL];           // 表示用
+// 表示用fieldはx = 1~10の配列でゲーム内の盤面管理
+// 内部用boardはx = 0~9の配列でゲーム内の盤面管理
+
 /* 座標
        -y
 　　　  ↑
@@ -56,5 +71,6 @@ extern int block_shape;
 extern Block *current_block;
 extern pthread_mutex_t block_mutex;
 extern int block_fixed;
+extern volatile InputType input_flag;
 
 #endif

--- a/tetris_game.h
+++ b/tetris_game.h
@@ -69,8 +69,8 @@ extern char field[ROW][COL];           // 表示用
 */
 extern int block_shape;
 extern Block *current_block;
-extern pthread_mutex_t block_mutex;
-extern int block_fixed;
+extern volatile int block_fixed;
 extern volatile InputType input_flag;
+extern pthread_mutex_t block_mutex;
 
 #endif


### PR DESCRIPTION
### 修正内容
- #### 移動や回転により壁を突き破る
   - 【原因】回転後のブロック表示箇所に壁や領域外があるか判定がなかったため。
   - 【解消】player.cの[64行目～65行目](https://github.com/tomobit6/tetris_app/pull/3/commits/d9d34bb63f3393bec6265f4bd5d04060e98636e5#diff-f0f2eb20b8abceda76a5b156876f96e9083a07f3c488d4cc06249665ed5dd56eR64-R65)で対策。回転した後の状態で、領域外もしくは、ブロックがすでにあれば、逆回転で元に戻す。[逆回転関数(rotate_block_reverse())は89行目～99行目](https://github.com/tomobit6/tetris_app/pull/3/files#diff-f0f2eb20b8abceda76a5b156876f96e9083a07f3c488d4cc06249665ed5dd56eR89-R99)
- #### 固定後のブロックが表示上では消えてしまう
   -  【原因】ブロックが下の障害物に衝突し固定する判定にブロックの盤面書き換え及び画面描画がされていないまま、ループを抜けて、次のブロックに処理が移っていた。
   -  【解消】ブロックの盤面書き換え及び画面描画をブロックの固定後に行い、その後ループを抜けて、次のブロックの処理へ進む。[(main.cの59行目～60行目)](https://github.com/tomobit6/tetris_app/pull/3/files#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR59-R60)