### PR TITLE
bugs #5の修正

### DIFF
--- a/game.c
+++ b/game.c
@@ -10,7 +10,6 @@ int game_over = 0;
 
 void init_game()
 {
-    system("cls");
     memset(board, 0, sizeof(board)); // boardの0初期化
 	game_over = 0;
     score = 0;

--- a/main.c
+++ b/main.c
@@ -32,6 +32,7 @@ pthread_mutex_t block_mutex = PTHREAD_MUTEX_INITIALIZER; // これ１個でい�
 int main(void)
 {
 	srand(time(0));
+	printf("\033[2J"); // 画面全消去
 	
 	init_game();
 	block_shape = rand() % BLOCK_TYPE_COUNT;
@@ -61,29 +62,42 @@ int main(void)
 			pthread_mutex_unlock(&block_mutex);
     	
     		int fall_timer = 0;
+    		int lock_delay = 0;
         	while (1)
         	{
             	// 入力処理 
             	handle_input();
-
+        		
             	// 衝突判定
             	if (is_collision(current_block))
             	{
-                	fixed_block(current_block);
+            		lock_delay += 10000;
             		
-                	pthread_mutex_lock(&block_mutex); // ロック
-                	block_fixed = 1;
-                	pthread_mutex_unlock(&block_mutex); // ロック解除
+    				if (lock_delay >= 200000)
+    				{
+        				fixed_block(current_block);
+    					
+    					pthread_mutex_lock(&block_mutex); // ロック
+                		block_fixed = 1;
+                		pthread_mutex_unlock(&block_mutex); // ロック解除
             		
-                	usleep(150000);
-                	clear_full_lines();
-                	usleep(150000);
-                	break;
+                		usleep(50000);
+                		clear_full_lines();
+                		usleep(50000);
+                		break;
+    				}
             	}
-        		if(fall_timer >= 400000)
+        		else
         		{
-            		// 自然落下
-            		current_block->py++;
+        			lock_delay = 0;
+        		}
+        		if(fall_timer >= 400000)
+    	    	{
+        	    	// 自然落下
+            		if (can_move(current_block, 0, 1))
+    				{
+        				current_block->py++;
+    				}
         			fall_timer = 0;
         		}
             	usleep(10000);

--- a/player.c
+++ b/player.c
@@ -61,8 +61,6 @@ void handle_input()
         break;
     case INPUT_ROTATE:
         rotate_block(current_block);
-        if (!can_move(current_block, 0, 0))      // 回転後に衝突するなら戻す。＋する分を0にして、今現状、領域外に行っているか確かめる
-            rotate_block_reverse(current_block); // 逆回転（未実装なら保存して戻す）
         break;
     default:
         break;
@@ -73,24 +71,41 @@ void handle_input()
 
 void rotate_block(Block *block)
 {
+	if (block->type == BLOCK_O)
+        return;
+	
     for (int i = 0; i < 4; i++)
     {
         int old_x = block->x[i];
         int old_y = block->y[i];
+
         block->x[i] = -old_y;
         block->y[i] = old_x;
     }
-    // 時計回り(90度回転)  x' = -y    y' = x
-    // 反時計回り(90度回転) x' = y    x' = -x
-/*
-	[ 0 -1 ]
-	[ 1  0 ]
-
-	これをかけると：
-	x' = 0*x + (-1)*y = -y
-	y' = 1*x +  0*y = x
-*/
-    block->rot = (block->rot + 1) % 4;
+	// 正常
+	if (can_move(block, 0, 0)){
+		block->rot = (block->rot + 1) % 4;
+    	return;
+	}
+	
+	// 左キック
+	if (can_move(block, -1, 0))
+	{
+    	block->px--;
+		block->rot = (block->rot + 1) % 4;
+    	return;
+	}
+	
+	// 右キック
+	if (can_move(block, 1, 0))
+	{
+    	block->px++;
+		block->rot = (block->rot + 1) % 4;
+    	return;
+	}
+	
+	// だめなら戻す
+	rotate_block_reverse(block);
 }
 
 void rotate_block_reverse(Block *block)
@@ -104,3 +119,14 @@ void rotate_block_reverse(Block *block)
     }
     block->rot = (block->rot + 3) % 4;
 }
+
+// 時計回り(90度回転)  x' = -y    y' = x
+// 反時計回り(90度回転) x' = y    x' = -x
+/*
+	[ 0 -1 ]
+	[ 1  0 ]
+
+	これをかけると：
+	x' = 0*x + (-1)*y = -y
+	y' = 1*x +  0*y = x
+*/

--- a/screen.c
+++ b/screen.c
@@ -70,6 +70,9 @@ void *print_screen(void *ptr)
         printf("\n");
 
         printf("SCORE: %d\n", score);
+    	
+    	// ちらつき防止
+    	fflush(stdout);
 
         pthread_mutex_unlock(&block_mutex);
 


### PR DESCRIPTION
バグ #5 の改修
- O型の回転が上に行く問題を解消。回転しない処理に。
- 固定前に、ブロックを少し動かせる余白を持たせた。
- 左右の壁に面した状態で回転できない。
   -  壁に面した状態で、回転する際、左なら右にずらして回転。右なら左にずらして回転。

- 画面のちらつきはfflushを入れたためかなりましになったが、カーソルが少し移動しているのが見える。
- ゲームオーバ判定はまだ厳しいまま。