### PR TITLE
feature/beep-and-fix/message-box

### DIFF
--- a/include/tetris_game.h
+++ b/include/tetris_game.h
@@ -8,8 +8,9 @@
 #include <time.h>    // time使用
 #include <conio.h>   // kbhit,getch使用
 #include <pthread.h> // スレッド,mutex使用(各ファイルスレッド使用)
+#include <windows.h> // Beep使用
 
-#define ROW 11 // 最後行枠用。上位2行ゲームオーバー用　　　　　 実際10
+#define ROW 14 // 最後行枠用。上位2行ゲームオーバー用　　　　　 実際13
 #define COL 13 // 1列目及び最終列 - 1枠用。最終列はnull文字用  実際10
 #define BOARD_WIDTH (COL - 3)
 #define BOARD_HEIGHT (ROW - 1)

--- a/src/game.c
+++ b/src/game.c
@@ -46,7 +46,6 @@ int update_game(int *fall_timer, int *lock_delay)
         if (*lock_delay >= LOCK_DELAY) // 衝突後固定までの猶予 衝突判定してから後19回横移動のキーを受け取るループ回る
         {
             fixed_block(current_block);
-
             pthread_mutex_lock(&block_mutex); // ロック
             block_fixed = 1;
             pthread_mutex_unlock(&block_mutex); // ロック解除
@@ -139,15 +138,19 @@ void clear_full_lines()
     {
     case 1:
         score += 100;
+        Beep(1000, 50);
         break;
     case 2:
         score += 300;
+        Beep(1200, 80);
         break;
     case 3:
         score += 500;
+        Beep(1400, 120);
         break;
     case 4:
         score += 800;
+        Beep(1800, 200);
         break;
     }
     pthread_mutex_unlock(&block_mutex); // ロック解除

--- a/src/main.c
+++ b/src/main.c
@@ -55,6 +55,9 @@ int main(void)
 			if (!can_move(current_block, 0, 0))
 			{
 				game_state = STATE_GAMEOVER;
+				Beep(500, 20);
+				Beep(700, 20);
+				Beep(1000, 50);
 				update_ranking(score);
 				break; // ゲームループ終了
 			}

--- a/src/screen.c
+++ b/src/screen.c
@@ -74,8 +74,7 @@ void *print_screen(void *ptr)
         offset += sprintf(screen + offset, "SCORE: %04d\n", score);
         pthread_mutex_unlock(&block_mutex);
 
-        // ポーズ画面
-        offset += sprintf(screen + offset, "\033[%d;1H", ROW + 2);
+        offset += sprintf(screen + offset, "\033[1;1H");
         switch (game_state)
         {
         case STATE_PAUSED:
@@ -129,42 +128,41 @@ void draw_box(char *screen, int *offset, int x, int y,
 
 void draw_pause_box(char *screen, int *offset)
 {
-    int x = 8;
-    int y = 5;
-    draw_box(screen, offset, x, y, 22, 7); // (x,yは座標5行目,8列目から描画)
+    int x = 1;
+    int y = 1;
+    draw_box(screen, offset, x, y, BOARD_WIDTH + 2, BOARD_HEIGHT + 1); // BOARD_WIDTH + 2 = 12 , BOARD_HEIGHT + 1 =11
+    *offset += sprintf(screen + *offset,
+                       "\033[%d;%dHPAUSED", y + 2, x + 3);
 
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHPAUSED", y + 1, x + 7);
+                       "\033[%d;%dHr: RESUME", y + 5, x + 1);
 
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHr : RESUME", y + 3, x + 3);
-
-    *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHq : QUIT", y + 4, x + 3);
+                       "\033[%d;%dHq: QUIT", y + 7, x + 1);
 }
 
 void draw_gameover_box(char *screen, int *offset)
 {
-    int x = 6;
-    int y = 3;
+    int x = 1;
+    int y = 1;
 
-    draw_box(screen, offset, x, y, 24, 12);
+    draw_box(screen, offset, x, y, BOARD_WIDTH + 2, BOARD_HEIGHT + 1); // BOARD_WIDTH + 2 = 12 , BOARD_HEIGHT + 1 =11
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHGAME OVER", y + 1, x + 6);
+                       "\033[%d;%dHGAMEOVER", y + 1, x + 2);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHSCORE : %04d", y + 3, x + 3, score);
+                       "\033[%d;%dHSCORE:%04d", y + 3, x + 1, score);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHRANKING", y + 5, x + 3);
+                       "\033[%d;%dHRANKING", y + 5, x + 2);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dH1. %04d", y + 6, x + 3, high_scores[0]);
+                       "\033[%d;%dH1. %04d", y + 6, x + 2, high_scores[0]);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dH2. %04d", y + 7, x + 3, high_scores[1]);
+                       "\033[%d;%dH2. %04d", y + 7, x + 2, high_scores[1]);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dH3. %04d", y + 8, x + 3, high_scores[2]);
+                       "\033[%d;%dH3. %04d", y + 8, x + 2, high_scores[2]);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHr : RETRY", y + 10, x + 3);
+                       "\033[%d;%dHr: RETRY", y + 10, x + 2);
     *offset += sprintf(screen + *offset,
-                       "\033[%d;%dHq : QUIT", y + 11, x + 3);
+                       "\033[%d;%dHq: QUIT", y + 11, x + 2);
 }
 
 void show_cursor()


### PR DESCRIPTION
#### beep音の追加
- 1列削除されたときに音を鳴らす
- ゲームオーバの際に音を鳴らす
ただ音を鳴らしているだけでゲーム性のある音ではない。
beep()はスレッドを止めてしまうので、それとの兼ね合いも考える

#### メッセージボックスの修正
- ゲームオーバ及びポーズのメッセージボックスの枠もテトリスと同じにし、すべて同じ枠内で表示(これによりoffset += sprintf(screen + offset, "\033[2J");を削除したことによる、ゲームオーバ枠、ポーズ画面枠のゲーム盤以外の枠表示残りを解消)